### PR TITLE
Use plugin_dir_url instead of magic url building to use relative type according to the current page (http or https)

### DIFF
--- a/features/metaboxes/init.php
+++ b/features/metaboxes/init.php
@@ -883,28 +883,12 @@ class pixproof_Meta_Box {
 
 	/**
 	 * Defines the url which is used to load local resources.
-	 * This may need to be filtered for local Window installations.
 	 * If resources do not load, please check the wiki for details.
 	 * @since  1.0.1
 	 * @return string URL to CMB resources
 	 */
 	public static function get_meta_box_url() {
-
-		if ( strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN' ) {
-			// Windows
-			$content_dir = str_replace( '/', DIRECTORY_SEPARATOR, WP_CONTENT_DIR );
-			$content_url = str_replace( $content_dir, WP_CONTENT_URL, dirname(__FILE__) );
-			$pixproof_url = str_replace( DIRECTORY_SEPARATOR, '/', $content_url );
-
-		} else {
-		  $pixproof_url = str_replace(
-				array(WP_CONTENT_DIR, WP_PLUGIN_DIR),
-				array(WP_CONTENT_URL, WP_PLUGIN_URL),
-				dirname( __FILE__ )
-			);
-		}
-
-		return trailingslashit( apply_filters('pixproof_meta_box_url', $pixproof_url ) );
+			return plugin_dir_url(__FILE__);
 	}
 
 	/**


### PR DESCRIPTION
I am using the LENS theme from pixelgrade: http://themeforest.net/item/lens-an-enjoyable-photography-wordpress-theme/5713452.
I configured my wordpress instance to force SSL for the login and admin page.
The overall page does not use SSL (and I do not want it to!)

If wordpress is configured as described above, the gallery detail page fails to load: the gallery images do not show up. Google Chrome prints errors on the console "Mixed Content".
The broken page is: `wp-admin/post.php?post=121&action=edit`
I digged into the code and the fix I provide fixes the issue.
However I am not a php expert nor do I know anything about wordpress plugin development. 

This only works in combination with pull request https://github.com/pixelgrade/pixtypes/pull/16 (The `pixtype` plugin also seems to lack the ability to serve resources correctly).

Please also note, that not all Mixed Content problems are gone.
I was only able to fix Errors, I still get warnings for each image in the gallery:
`Mixed Content: The page at 'https://example.com/wp-admin/post.php?post=42&action=edit' was loaded over HTTPS, but requested an insecure image 'http://example.com/wp-content/uploads/2014/11/image-300x225.jpg'. This content should also be served over HTTPS.`
